### PR TITLE
Optimize icon lookup

### DIFF
--- a/icon-find.c
+++ b/icon-find.c
@@ -331,8 +331,8 @@ void icon_find(struct sbuf *name, int size)
 	requested_icon_size = size;
 
 	/* Search through $XDG_DATA_DIRS/icons/<theme>/ */
-	list_for_each_entry(s, &icon_dirs, list) {
-		list_for_each_entry(t, &theme_list, list) {
+	list_for_each_entry(t, &theme_list, list) {
+		list_for_each_entry(s, &icon_dirs, list) {
 			sbuf_cpy(&most_suitable_icon, "");
 			sbuf_cpy(&path, s->buf);
 			sbuf_addch(&path, '/');

--- a/icon-find.c
+++ b/icon-find.c
@@ -12,8 +12,8 @@
 #include "list.h"
 #include "util.h"
 
-#define DEBUG_PRINT_FINAL_SELECTION 1
-#define DEBUG_PRINT_ALL_HITS 1		/* regardless of size */
+#define DEBUG_PRINT_FINAL_SELECTION 0
+#define DEBUG_PRINT_ALL_HITS 0		/* regardless of size */
 #define DEBUG_PRINT_INHERITED_THEMES 0
 #define DEBUG_PRINT_ICON_DIRS 0
 

--- a/icon-find.c
+++ b/icon-find.c
@@ -12,7 +12,7 @@
 #include "list.h"
 #include "util.h"
 
-#define DEBUG_PRINT_FINAL_SELECTION 0
+#define DEBUG_PRINT_FINAL_SELECTION 1
 #define DEBUG_PRINT_ALL_HITS 1		/* regardless of size */
 #define DEBUG_PRINT_INHERITED_THEMES 0
 #define DEBUG_PRINT_ICON_DIRS 0
@@ -62,7 +62,7 @@ static void get_parent_themes(struct list_head *parent_themes, const char *child
 
 			if (!strncmp(option, "Inherits", 8)) {
 				if (DEBUG_PRINT_INHERITED_THEMES)
-					printf("%s inherits %s\n", child_theme, value);
+					fprintf(stderr, "%s inherits %s\n", child_theme, value);
 				sbuf_split(parent_themes, value, ',');
 				fclose(fp);
 				goto out2;
@@ -127,10 +127,10 @@ void icon_find_print_themes(void)
 {
 	struct sbuf *t;
 
-	printf("THEMES: ");
+	fprintf(stderr, "THEMES: ");
 	list_for_each_entry(t, &theme_list, list)
-		printf("%s, ", t->buf);
-	printf("\n");
+		fprintf(stderr, "%s, ", t->buf);
+	fprintf(stderr, "\n");
 }
 
 static void init_theme_list(void)
@@ -149,7 +149,7 @@ static void init_icon_dirs(void)
 
 	if (DEBUG_PRINT_ICON_DIRS)
 		list_for_each_entry(path, &icon_dirs, list)
-			printf("%s\n", path->buf);
+			fprintf(stderr, "%s\n", path->buf);
 }
 
 static void init_pixmap_dirs(void)
@@ -214,23 +214,22 @@ static void process_file(const char *fpath)
 		return;
 
 	if (DEBUG_PRINT_ALL_HITS)
-		printf("%s - %d", fpath, size_of_this_one);
+		fprintf(stderr, "    %s:%d:%s: %s - %d\n",
+			   __FILE__, __LINE__, __FUNCTION__, fpath, size_of_this_one);
 
 	if (!smallest_match &&
 	    size_of_this_one >= requested_icon_size) {
 		smallest_match = size_of_this_one;
 		sbuf_cpy(&most_suitable_icon, fpath);
 		if (DEBUG_PRINT_ALL_HITS)
-			printf(" - Grab");
+			fprintf(stderr, "    %s:%d:%s: Grab\n", __FILE__, __LINE__, __FUNCTION__);
 	} else if (size_of_this_one < smallest_match &&
 		   size_of_this_one >= requested_icon_size) {
 		smallest_match = size_of_this_one;
 		sbuf_cpy(&most_suitable_icon, fpath);
 		if (DEBUG_PRINT_ALL_HITS)
-			printf(" - Grab");
+			fprintf(stderr, "    %s:%d:%s: Grab\n", __FILE__, __LINE__, __FUNCTION__);
 	}
-	if (DEBUG_PRINT_ALL_HITS)
-		printf("\n");
 }
 
 /*
@@ -347,7 +346,7 @@ void icon_find(struct sbuf *name, int size)
 			search_dir_for_file(path.buf, name->buf);
 
 			if (DEBUG_PRINT_FINAL_SELECTION && most_suitable_icon.len)
-				printf("OUTPUT: %s\n", most_suitable_icon.buf);
+				fprintf(stderr, "OUTPUT: %s\n", most_suitable_icon.buf);
 
 			if (most_suitable_icon.len)
 				goto out;

--- a/icon-find.c
+++ b/icon-find.c
@@ -219,7 +219,7 @@ static void process_file(const char *fpath)
 	if (!smallest_match &&
 	    size_of_this_one >= requested_icon_size) {
 		smallest_match = size_of_this_one;
-		sbuf_addstr(&most_suitable_icon, fpath);
+		sbuf_cpy(&most_suitable_icon, fpath);
 		if (DEBUG_PRINT_ALL_HITS)
 			printf(" - Grab");
 	} else if (size_of_this_one < smallest_match &&

--- a/icon-find.h
+++ b/icon-find.h
@@ -5,9 +5,19 @@
 
 #include "sbuf.h"
 
+struct icon_path {
+	struct sbuf name;
+	struct sbuf path;
+	int smallest_match;
+	int found;
+	void *icon;
+	struct list_head list;
+};
+
 extern void icon_find_add_theme(const char *theme);
 extern void icon_find_print_themes(void);
 extern void icon_find_init(void);
 extern void icon_find(struct sbuf *name, int size);
+extern void icon_find_all(struct list_head *icons, int size);
 
 #endif /* ICON_FIND_H */

--- a/icon.c
+++ b/icon.c
@@ -21,7 +21,7 @@
 #include "sbuf.h"
 #include "xpm-loader.h"
 
-#define DEBUG_THEMES 0
+#define DEBUG_THEMES 1
 
 struct icon {
 	char *name;
@@ -110,6 +110,8 @@ void icon_set_name(const char *name)
 
 void icon_load(void)
 {
+	if (DEBUG_THEMES)
+		fprintf(stderr, "%s:%d %s:\n", __FILE__, __LINE__, __FUNCTION__);
 	struct icon *icon;
 	struct sbuf s;
 	static int first_load = 1;

--- a/icon.c
+++ b/icon.c
@@ -21,7 +21,7 @@
 #include "sbuf.h"
 #include "xpm-loader.h"
 
-#define DEBUG_THEMES 1
+#define DEBUG_THEMES 0
 
 struct icon {
 	char *name;

--- a/jgmenu-cache.sh
+++ b/jgmenu-cache.sh
@@ -2,7 +2,6 @@
 
 IFS="$(printf '\n\t')"
 
-
 die () {
 	printf "fatal: %s\n" "$1"
 	exit 1
@@ -106,8 +105,8 @@ create_symlinks () {
 		else
 			test ${verbose} = "t" && echo "[ CREATE  ] ${f}"
 			ln -s "$(jgmenu-icon-find --theme=${icon_theme} \
-				 --icon-size=${icon_size} ${f})" \
-			      ${1} >/dev/null 2>&1
+			   --icon-size=${icon_size} ${f} 2>/dev/null)" \
+				    ${1} >/dev/null 2>&1
 		fi
 	done
 }

--- a/jgmenu.c
+++ b/jgmenu.c
@@ -31,7 +31,7 @@
 #include "filter.h"
 #include "list.h"
 
-#define DEBUG_ICONS_LOADED_NOTIFICATION 0
+#define DEBUG_ICONS_LOADED_NOTIFICATION 1
 
 #define MAX_FIELDS 3		/* nr fields to parse for each stdin line */
 

--- a/jgmenu.c
+++ b/jgmenu.c
@@ -19,6 +19,7 @@
 #include <errno.h>
 #include <math.h>
 #include <sys/stat.h>
+#include <time.h>
 
 #include "x11-ui.h"
 #include "config.h"
@@ -914,13 +915,27 @@ void dlist_append(struct item *item, struct item **list, struct item **last)
 	*last = item;
 }
 
+static double timespec_to_sec(struct timespec* ts)
+{
+	return (double)ts->tv_sec + (double)ts->tv_nsec / 1000000000.0;
+}
+
 /*
  * This function is loaded in the background under a new pthread
  * X11 is not thread-safe, so load_icons() must not call any X functions.
  */
 void *load_icons(void *arg)
 {
+	struct timespec ts_start;
+	struct timespec ts_end;
+	double duration;
+	clock_gettime(CLOCK_MONOTONIC, &ts_start);
 	icon_load();
+	clock_gettime(CLOCK_MONOTONIC, &ts_end);
+	if (DEBUG_ICONS_LOADED_NOTIFICATION) {
+		 duration = timespec_to_sec(&ts_end) - timespec_to_sec(&ts_start);
+		 fprintf(stderr, "Icons loaded in %f seconds\n", duration);
+	}
 
 	if (write(pipe_fds[1], "x", 1) == -1)
 		die("error writing to icon_pipe");


### PR DESCRIPTION
Benchmarks for `jgmenu pmenu` without a cache:

Remove cache:

```
rm -rf ~/.local/share/icons/jgmenu-cache
```

Old version:

```
git checkout 19fb4f0
make clean ; make ; make install
# flush disk caches
sudo sh -c 'echo 3 > /proc/sys/vm/drop_caches; for d in /dev/sd* ; do hdparm -F $d ; done'
time jgmenu_run pmenu --die-when-loaded
warning: jgmenu icon-cache has not been created
Failed to load XPM file: /opt/eclipse/icon.xpm
jgmenu_run pmenu --die-when-loaded  0.28s user 1.16s system 82% cpu 1.753 total
# number of disk accesses:
strace -f jgmenu_run pmenu --die-when-loaded 2>&1 | grep -E 'open|stat|access|link' | wc -l
57141
```

New version:

```
git checkout 79ce8b0
make clean ; make ; make install
# flush disk caches
sudo sh -c 'echo 3 > /proc/sys/vm/drop_caches; for d in /dev/sd* ; do hdparm -F $d ; done'
time jgmenu_run pmenu --die-when-loaded
warning: jgmenu icon-cache has not been created
Icons loaded in 0.053772 seconds
Root menu icons loaded
Failed to load XPM file: /opt/eclipse/icon.xpm
Icons loaded in 0.275449 seconds
jgmenu_run pmenu --die-when-loaded  0.28s user 0.06s system 56% cpu 0.605 total
# number of disk accesses:
strace -f jgmenu_run pmenu --die-when-loaded 2>&1 | grep -E 'open|stat|access|link' | wc -l 
3868
```

Note that the loading time is 3x smaller and the number of disk accesses is 15x smaller.

`jgmenu_run cache` will have to be fixed, it is looking up icons one by one:

Old version:

```
# number of disk accesses:
strace -f jgmenu_run cache 2>&1 | grep -E 'open|stat|access|link' | wc -l                  
1384368
```

New version:
```
# number of disk accesses:
strace -f jgmenu_run cache 2>&1 | grep -E 'open|stat|access|link' | wc -l
66826
```

Note that this is much worse than starting without a cache at all! (However, after the cache is created, jgmenu runs quickly. My point is that creating the cache is a bit slow.)