### PR TITLE
Pmenu fixes

### DIFF
--- a/jgmenu-parse-pmenu.py
+++ b/jgmenu-parse-pmenu.py
@@ -216,7 +216,7 @@ def internationalized(entry):
 # A special key "_path" stores the path of the file
 def read_desktop_entry(path):
   entry = {}
-  with open(path, "r") as f:
+  with open(path, "r", encoding="utf-8") as f:
     lines = f.read().split("\n")
     inside = False
     for line in lines:

--- a/jgmenu-parse-pmenu.py
+++ b/jgmenu-parse-pmenu.py
@@ -169,7 +169,7 @@ strings = {
 # The empty string is always the last element.
 def get_current_locale_names():
   # E.g. "en_US"
-  lang = locale.getlocale()[0]
+  lang = locale.getlocale()[0] or "en_US"
   # ["en", "US"]
   lang_parts = lang.split("_")
   locale_names = [""]


### PR DESCRIPTION
Fixed two crashes on a system where the locale was not set, so the default encoding was ASCII instead of UTF-8.