### PR TITLE
debian: Reflect recent changes in build system

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -11,7 +11,7 @@ Build-Depends: debhelper (>= 9),
                librsvg2-dev,
                libxml2-dev,
                libglib2.0-dev,
-               libmenu-cache-dev (>= 1.1) | libmenu-cache-dev (<< 1.1),
+               libmenu-cache-dev,
                pkg-config
 
 Package: jgmenu

--- a/debian/rules
+++ b/debian/rules
@@ -1,8 +1,5 @@
 #!/usr/bin/make -f
 
-_LMC_VERSION := $(shell pkg-config --modversion libmenu-cache)
-_JGMENU_NO_LX := $(shell dpkg --compare-versions $(_LMC_VERSION) '<<' 1.1 && echo 1 || echo 0)
-
 %:
 	dh $@
 
@@ -10,7 +7,7 @@ override_dh_auto_configure:
 	true
 
 override_dh_auto_build:
-	dh_auto_build -- NO_LX=$(_JGMENU_NO_LX)
+	dh_auto_build
 
 override_dh_auto_install:
-	dh_auto_install -- prefix=/usr NO_LX=$(_JGMENU_NO_LX)
+	dh_auto_install -- prefix=/usr


### PR DESCRIPTION
NO_LX detection made superfluous in 473cacd44878e8791de8e618e94a121caa07e190.