### PR TITLE
debian/rules: omit broken dh_auto_clean target (and add some buildflags)

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -1,10 +1,21 @@
 #!/usr/bin/make -f
 
+export DEB_BUILD_MAINT_OPTIONS   = hardening=+all
+export DPKG_EXPORT_BUILDFLAGS    = 1
+export DH_VERBOSE                = 1
+
+include /usr/share/dpkg/buildflags.mk
+
 %:
 	dh $@
 
+override_dh_auto_clean:
+	# Broken due to `make clean` relying on dependencies like pkg-config being
+	# installed and executing.
+	@true
+
 override_dh_auto_configure:
-	true
+	@true
 
 override_dh_auto_build:
 	dh_auto_build


### PR DESCRIPTION
Because the makefile system's 'clean' target relies on dependencies being
installed which are not in a minimal Debian system by way of pkg-config
invocations, even without compiling, the pdebuild routines will fail (it is an idiotic choice, but
pdebuild executes the dh_auto_clean target on the host it is invoked by, not inside
the build chroot).

Override dh_auto_clean to be a noop as a workaround as redoing the makefile
system is a larger task.

Additionally, export distro build flags.

---

Error:

$ sudo pdebuild --buildresult ../stretch-backports-amd64/  --pbuildersatisfydepends /usr/lib/pbuilder/pbuilder-satisfydepends-aptitude --debbuildopts  -sa -- --basetgz /var/cache/pbuilder/stretch_amd64.tgz   ; s
udo pdebuild --buildresult ../stretch-backports-i386/  --pbu
ildersatisfydepends /usr/lib/pbuilder/pbuilder-satisfydepends-aptitude --debbuildopts  -sa -- --basetgz /var/cache/pbuilder/stretch_i386
.tgz
W: /root/.pbuilderrc does not exist
dpkg-checkbuilddeps: error: Unmet build dependencies: libx11-dev libxrandr-dev libcairo2-dev libpango1.0-dev librsvg2-dev
W: Unmet build-dependency in source
dh clean
   dh_testdir
   dh_auto_clean
        make -j1 distclean
make[1]: Entering directory '/home/bunsen/PKG/backports/jgmenu_new/jgmenu'
Makefile:19: *** fatal: could not find library 'x11'.  Stop.
make[1]: Leaving directory '/home/bunsen/PKG/backports/jgmenu_new/jgmenu'
dh_auto_clean: make -j1 distclean returned exit code 2
debian/rules:10: recipe for target 'clean' failed
make: *** [clean] Error 2
W: /root/.pbuilderrc does not exist
dpkg-checkbuilddeps: error: Unmet build dependencies: libx11-dev libxrandr-dev libcairo2-dev libpango1.0-dev librsvg2-dev
W: Unmet build-dependency in source
dh clean
   dh_testdir
   dh_auto_clean
        make -j1 distclean
make[1]: Entering directory '/home/bunsen/PKG/backports/jgmenu_new/jgmenu'
Makefile:19: *** fatal: could not find library 'x11'.  Stop.
make[1]: Leaving directory '/home/bunsen/PKG/backports/jgmenu_new/jgmenu'
dh_auto_clean: make -j1 distclean returned exit code 2
debian/rules:10: recipe for target 'clean' failed
make: *** [clean] Error 2