### PR TITLE
Update .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ compiler:
   - gcc
   - clang
 
-sudo: false
+sudo: true
 
 addons:
   apt:
@@ -17,8 +17,13 @@ addons:
       - libxrandr-dev
       - libpango1.0-dev
       - libmenu-cache-dev
-
-script: make && make test
+      - checkinstall
+      - clang-3.5
+      - clang
+      - clang++-3.5
+      - gcc
+      
+script: make && make test && sudo checkinstall --install=no -y
 
 env:
   global:
@@ -27,3 +32,12 @@ env:
 
 after_success:
   - bash <(curl -s https://codecov.io/bash)
+  - #https://github.com/probonopd/uploadtool/
+  - # ls -lh out/* Assuming you have some files in out/ that you would like to upload 
+  - wget -c https://github.com/probonopd/uploadtool/raw/master/upload.sh
+  - bash upload.sh jgmenu_*_amd64.deb
+
+branches:
+  except:
+    - # Do not build tags that we create when we upload to GitHub Releases
+    - /^(?i:continuous)$/

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ env:
 after_success:
   - bash <(curl -s https://codecov.io/bash)
   - #https://github.com/probonopd/uploadtool/
-  - # ls -lh out/* Assuming you have some files in out/ that you would like to upload 
+  - # ls -lh out/* Assuming you have some files in out/ that you would like to upload
   - wget -c https://github.com/probonopd/uploadtool/raw/master/upload.sh
   - bash upload.sh jgmenu_*_amd64.deb
 


### PR DESCRIPTION
See https://github.com/johanmalm/jgmenu/issues/80

This PR builds a deb package using Travis CI, which should then automatically be uploaded to git after.

error while loading shared libraries: libpng12.so.0
Fix: http://security.ubuntu.com/ubuntu/pool/main/libp/libpng/libpng12-0_1.2.54-1ubuntu1.1_amd64.deb