### PR TITLE
Debian packaging fixes for v4.2.0

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -6,7 +6,7 @@ Standards-Version: 4.3.0
 Homepage: https://jgmenu.github.io/
 Build-Depends: debhelper (>= 10), libx11-dev, libxrandr-dev, libcairo2-dev,
  libpango1.0-dev, librsvg2-dev, libxml2-dev, libglib2.0-dev, libmenu-cache-dev,
- pkg-config, xfce4-panel-dev
+ pkg-config, libxfce4panel-2.0-dev
 
 Package: jgmenu
 Architecture: any

--- a/debian/jgmenu-xfce4-panel-applet.install
+++ b/debian/jgmenu-xfce4-panel-applet.install
@@ -1,2 +1,2 @@
-usr/lib/*/xfce4/*
-usr/share/xfce4/panel/plugins/*
+usr/lib/xfce4/*
+usr/share/xfce4/*


### PR DESCRIPTION
Changes in v4.2.0 have left behind the packaging in /debian, causing package builds to fail. Here are the fixes that allow the package to build successfully again. For the commits that introduced the problems in the first place, see the respective commit messages.