### PR TITLE
Working directory support for jgmenu-app

### DIFF
--- a/src/desktop.c
+++ b/src/desktop.c
@@ -48,6 +48,8 @@ static void parse_line(char *line, struct app *app, int *is_desktop_entry)
 		strlcpy(app->exec, value, sizeof(app->exec));
 	} else if (!strcmp("TryExec", key)) {
 		strlcpy(app->tryexec, value, sizeof(app->tryexec));
+	} else if (!strcmp("Path", key)) {
+		strlcpy(app->working_dir, value, sizeof(app->working_dir));
 	} else if (!strcmp("Icon", key)) {
 		strlcpy(app->icon, value, sizeof(app->icon));
 	} else if (!strcmp("Categories", key)) {

--- a/src/desktop.h
+++ b/src/desktop.h
@@ -12,6 +12,7 @@ struct app {
 	char generic_name_localized[128];
 	char exec[1024];
 	char tryexec[1024];
+	char working_dir[1024];
 	bool tryexec_not_in_path;
 	char icon[128];
 	char categories[1024];

--- a/src/jgmenu-apps.c
+++ b/src/jgmenu-apps.c
@@ -75,10 +75,11 @@ static void print_app_to_buffer(struct app *app, struct sbuf *buf)
 
 	/* icon */
 	sbuf_addstr(buf, app->icon);
-	sbuf_addstr(buf, ",,");
+	sbuf_addstr(buf, ",");
 
 	/* working directory */
-	/* TODO */
+	sbuf_addstr(buf, app->working_dir);
+	sbuf_addstr(buf, ",");
 
 	/* metadata */
 	replace_semicolons_with_hashes(app->categories);


### PR DESCRIPTION
Adds support for pulling the working directory out of desktop files and passing it along.

Code should be pretty self-explanatory.