### PR TITLE
Add convenience keys

### DIFF
--- a/docs/manual/jgmenu.1.md
+++ b/docs/manual/jgmenu.1.md
@@ -237,11 +237,11 @@ Icons will be displayed if the third field is populated, for example:
 
 # USER INTERFACE
 
-`Up`, `Down`
+`Up`, `Down`, `Ctrl+p`, `Ctrl+n`
 
 :   Select previous/next item
 
-`Left`. `Right`
+`Left`, `Right`
 
 :   Move to parent/sub menu
 
@@ -273,9 +273,21 @@ Icons will be displayed if the third field is populated, for example:
 
 :   exit(0)
 
+`Escape`, `Ctrl+c`, `Ctrl+[`
+
+:   Clear filter and then hide or exit jgmenu
+
 `Backspace`
 
 :   Return to parent menu
+
+`Ctrl+w`
+
+:   Backward erase word
+
+`Ctrl+u`
+
+:   Backward erase line
 
 Type any string to invoke a search. Words separated by space will be searched
 for using `OR` logic (i.e. the match of either word is sufficient to display an

--- a/src/filter.c
+++ b/src/filter.c
@@ -77,6 +77,18 @@ void filter_backspace(void)
 	filter_backspace();
 }
 
+void filter_delword(void)
+{
+	if (!has_been_inited)
+		die("filter has not been initiated");
+	if (!needle.len)
+		return;
+
+	do {
+		filter_backspace();
+	} while (!isspace(needle.buf[needle.len-1]) && needle.len);
+}
+
 void filter_reset(void)
 {
 	BUG_ON(!has_been_inited);

--- a/src/filter.h
+++ b/src/filter.h
@@ -8,6 +8,7 @@ int filter_get_clear_on_keyboard_input(void);
 void filter_set_clear_on_keyboard_input(int clear);
 void filter_addstr(const char *str, size_t n);
 void filter_backspace(void);
+void filter_delword(void);
 void filter_reset(void);
 int filter_needle_length(void);
 char *filter_needle(void);

--- a/src/jgmenu.c
+++ b/src/jgmenu.c
@@ -1671,6 +1671,14 @@ static void key_event(XKeyEvent *ev)
 	case XK_Super_R:
 		super_key_pressed = 1;
 		break;
+	case XK_bracketleft:
+		if (!(ev->state & ControlMask))
+			goto default_case;
+		[[fallthrough]];
+	case XK_c:
+		if (!(ev->state & ControlMask))
+			goto default_case;
+		[[fallthrough]];
 	case XK_Escape:
 		if (filter_needle_length()) {
 			filter_reset();
@@ -1689,6 +1697,10 @@ static void key_event(XKeyEvent *ev)
 		menu.current_node->last_sel = menu.sel;
 		draw_menu();
 		break;
+	case XK_p:
+		if (!(ev->state & ControlMask))
+			goto default_case;
+		[[fallthrough]];
 	case XK_Up:
 		if (widgets_get_kb_grabbed()) {
 			widgets_select("XK_Up");
@@ -1754,6 +1766,10 @@ static void key_event(XKeyEvent *ev)
 		if (menu.sel && menu.sel->selectable)
 			action_cmd(menu.sel->cmd, menu.sel->working_dir);
 		break;
+	case XK_n:
+		if (!(ev->state & ControlMask))
+			goto default_case;
+		[[fallthrough]];
 	case XK_Down:
 		if (widgets_get_kb_grabbed()) {
 			widgets_select("XK_Down");
@@ -1820,7 +1836,20 @@ static void key_event(XKeyEvent *ev)
 			update(1);
 		}
 		break;
+	case XK_w:
+		if (!(ev->state & ControlMask))
+			goto default_case;
+		filter_delword();
+		update(0);
+		break;
+	case XK_u:
+		if (!(ev->state & ControlMask))
+			goto default_case;
+		filter_reset();
+		update(0);
+		break;
 	default:
+default_case:
 		if (filter_get_clear_on_keyboard_input())
 			filter_reset();
 		filter_addstr(buf, len);


### PR DESCRIPTION
Add Ctrl+n and Ctrl+p to select next/previous item (Emacs like).
Add Ctrl+c and Ctrl+[ to abort (VIM-like alternatives to Escape).
Add Ctrl+u as an alternative to Escape where a second typing does not quit the menu.
Add Ctrl+w with delete word back functionality.