### PR TITLE
Manual page csv_cmd example fix

### DIFF
--- a/docs/manual/jgmenu.1.md
+++ b/docs/manual/jgmenu.1.md
@@ -448,7 +448,7 @@ Here follow some specific types:
     careful!). If left blank, jgmenu will read from `stdin`. Examples:
 
         csv_cmd = lx
-        csv_cmd = jgmenu_run lx --no-dirs
+        csv_cmd = JGMENU_NO_DIRS=1 jgmenu_run lx
         csv_cmd = cat ~/mymenu.csv
 
 `tint2_look` = __boolean__ (default 0)


### PR DESCRIPTION
The manual page's `csv_cmd=` parameter example `jgmenu_run lx --no-dirs` is wrong.

`jgmenu_run lx`/`jgmenu-lx` does not accept any command line parameters but uses environment variables exclusively, also for "no dirs" ([see the manpage](https://github.com/jgmenu/jgmenu/blob/master/docs/manual/jgmenu-lx.1.md)).

This fixes it with the env.  variable prepended.